### PR TITLE
Add acknowledgement of Orange UI SDK deployment code

### DIFF
--- a/Source/uOrangeUISmartSDKDeployment.pas
+++ b/Source/uOrangeUISmartSDKDeployment.pas
@@ -11,6 +11,12 @@ uses
     System.Win.Registry,
   {$ENDIF MSWINDOWS}
 
+{
+  Based on https://github.com/DelphiTeacher/OrangeFreeSDK/blob/master/OrangeSDKSmartDeployment/uOrangeUISmartSDKDeployment.pas
+  from the OrangeFreeSDK project - https://github.com/DelphiTeacher/OrangeFreeSDK project
+  By Delphi Teacher - https://github.com/DelphiTeacher
+}
+
   System.SysUtils,
   System.Variants,
   XMLDoc,


### PR DESCRIPTION
The uOrangeUISDKDeployment unit seems to be substantially based on the Orange UI project's unit of a similar name.

See:

[https://github.com/DelphiTeacher/OrangeFreeSDK/blob/master/OrangeSDKSmartDeployment/uOrangeUISmartSDKDeployment.pas](https://github.com/DelphiTeacher/OrangeFreeSDK/blob/master/OrangeSDKSmartDeployment/uOrangeUISmartSDKDeployment.pas
)

I didn't see an acknowledgement of this anywhere (which is required by the default license) so I added a comment to relevant unit to avoid accusations of plagiarism.

Maybe they based their code on yours? It doesn't seem likely though due to your choice of name for the unit. 😃 

I haven't checked any other units for similar uncredited derivation so it might be worth going through any you are aware of and updating them or adding a readme as necessary.